### PR TITLE
Fix white text in dark mode GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1059,6 +1059,9 @@ AX DX 하자면서 API 하나 안줘~!
             self.update_status_bar() # 최종 상태 반영
 
 def main():
+    if sys.platform.startswith("win"):
+        # Disable Qt dark mode on Windows so text colors stay visible
+        os.environ.setdefault("QT_QPA_PLATFORM", "windows:darkmode=0")
     app = QApplication(sys.argv)
     
     # 전역 폰트 설정


### PR DESCRIPTION
## Summary
- force Qt to ignore Windows dark mode so text uses light palette

## Testing
- `python -m py_compile gui.py`
- `python -m py_compile main.py utils.py`
- `python -m py_compile eep_checker/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6843f5a583bc832f9bb862f27e281c48