### PR TITLE
Update prompts for conciseness

### DIFF
--- a/eep_checker/prompt.py
+++ b/eep_checker/prompt.py
@@ -1,16 +1,13 @@
 def make_llm_prompt(file_name, func_name, enum_name, from_value, to_value, code, callers=None):
-    prompt = f"""
-[File: {file_name}]  |  Function: {func_name}  |  Enum: {enum_name}:{from_value} → {to_value}]
+    """Return a concise prompt for LLM analysis."""
 
-1. 함수 역할 (Function: {func_name})
-2. {enum_name}이(가) {func_name} 함수 내에서 쓰인 위치 및 의미
-3. {enum_name} 값 변경 시 {func_name} 함수에 미치는 영향
-   - 원인
-   - 분기/로직 변화
-   - 호출/반환 값 변화 가능성
-4. {func_name} 함수 수정 제안 및 테스트 포인트
-5. 심각도 (Function: {func_name})
-   - 이유와 ★★★☆☆ (3/5) 등으로 간략하게 표시
+    prompt = f"""
+[File: {file_name}] | Function: {func_name} | Enum: {enum_name} {from_value} → {to_value}]
+
+- {func_name}의 역할과 {enum_name} 사용 위치를 2문장 이내로 요약
+- {enum_name} 변경 시 예상 영향과 놓치기 쉬운 엣지 케이스 정리
+- 수정 제안과 테스트 포인트를 핵심 위주로 제시
+- 변경 심각도를 ★1~5로 표시하고 간단한 이유 덧붙이기
 
 ```c
 // Code for: {func_name}
@@ -19,15 +16,14 @@ def make_llm_prompt(file_name, func_name, enum_name, from_value, to_value, code,
 """
 
     if callers:
-        prompt += "\n\n--- 이 함수를 호출하는 함수들 ---"
+        prompt += "\n\n--- 호출자 함수 요약 ---"
         for caller in callers:
             prompt += f"""
 
-[Caller Function: {caller['func_name']} (in {file_name}) - Calls {func_name} at line {caller['call_line']}]
+[Caller: {caller['func_name']} in {file_name}, line {caller['call_line']}]
 
-1. {caller['func_name']} 함수의 역할 및 {func_name} 함수 호출부 분석
-2. {func_name} 함수의 변경이 {caller['func_name']} 함수에 미칠 수 있는 영향
-3. {caller['func_name']} 함수에서 필요한 수정이나 확인 사항
+- {caller['func_name']}의 역할과 {func_name} 호출 이유를 2문장 이내로 설명
+- {func_name} 수정 시 {caller['func_name']}에 미칠 영향과 확인 포인트
 
 ```c
 // Code for: {caller['func_name']}


### PR DESCRIPTION
## Summary
- refine `make_llm_prompt` to generate shorter, focused instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843f986009c832fa9045ec1b208d851